### PR TITLE
Add geo related params to Venue Search

### DIFF
--- a/src/Ticketmaster.Discovery/Models/SearchVenuesQueryParameters.cs
+++ b/src/Ticketmaster.Discovery/Models/SearchVenuesQueryParameters.cs
@@ -26,6 +26,10 @@ namespace Ticketmaster.Discovery.Models
         stateCode = 6,
         countryCode = 7,
         includeTest = 8,
-        source = 9
+        source = 9,
+        geoPoint = 10,
+        radius = 11,
+        unit = 12
+        
     }
 }

--- a/src/Ticketmaster.Discovery/Models/SearchVenuesQueryParameters.cs
+++ b/src/Ticketmaster.Discovery/Models/SearchVenuesQueryParameters.cs
@@ -1,9 +1,9 @@
-﻿//   Copyright © 2015-2026 Serhii Voznyi and open source community
+﻿//   Copyright © 2015-2026 Serhii Voznyi and the open source community
 //
 //     https://www.linkedin.com/in/serhii-voznyi/
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
-//   you may not use this file except in compliance with the License.
+//   You may not use this file except in compliance with the License.
 //   You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0
@@ -30,6 +30,5 @@ namespace Ticketmaster.Discovery.Models
         geoPoint = 10,
         radius = 11,
         unit = 12
-        
     }
 }


### PR DESCRIPTION
This PR adds parameters related to geo searches to the `SearchVenuesQueryParameters` to support searching for venues by `geoPoint`.

```
https://app.ticketmaster.com/discovery/v2/venues?countryCode=US&size=200&page=0&apikey={{TM_API_KEY}}&stateCode=NY&geoPoint=dr5r9&radius=10&unit=km
```

See Ticketmaster Discovery API docs:  https://github.com/SerhiiVoznyi/Ticketmaster-SDK/blob/master/src/Ticketmaster.Discovery/Models/SearchVenuesQueryParameters.cs

